### PR TITLE
Fix multiple network calls read.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,5 @@
 {
     "configurations": [
-    
         {
             "type": "node-terminal",
             "name": "Run Script: NFTservice test",
@@ -13,6 +12,13 @@
             "name": "Run Script: Charged test",
             "request": "launch",
             "command": "yarn run test Charged.test.ts --no-cache",
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "node-terminal",
+            "name": "Run Script: ERC20 Service",
+            "request": "launch",
+            "command": "yarn run test test/integration/Erc20Service.test.ts --no-cache",
             "cwd": "${workspaceFolder}"
         }
     ]

--- a/src/charged/services/baseService.ts
+++ b/src/charged/services/baseService.ts
@@ -25,7 +25,9 @@ export default class BaseService {
     const provider = providers[network] ?? providers['external'];
     const address = contractAddress ?? getAddress(network, contractName);
 
-    if (!this.contractInstances[action][address]) {
+    const contractUuid = address.concat(String(network));
+
+    if (!this.contractInstances[action][contractUuid]) {
 
       if (action === 'read') {
         const requestedContract = new ethers.Contract(
@@ -34,7 +36,7 @@ export default class BaseService {
           provider
         );
 
-        this.contractInstances[action][address] = requestedContract;
+        this.contractInstances[action][contractUuid] = requestedContract;
 
       } else if (action === 'write') {
         if (!signer && !providers['external']) { throw new Error('Trying to write with no signer') };
@@ -48,11 +50,11 @@ export default class BaseService {
           writeProvider
         );
 
-        this.contractInstances[action][address] = requestedContract;
+        this.contractInstances[action][contractUuid] = requestedContract;
       }
     }
 
-    return this.contractInstances[action][address];
+    return this.contractInstances[action][contractUuid];
   }
 
   public async fetchAllNetworks(

--- a/test/integration/Erc20Service.test.ts
+++ b/test/integration/Erc20Service.test.ts
@@ -43,7 +43,7 @@ describe('NFT service class', () => {
     expect(allowanceBalance.toString()).toEqual('100000000');
   });
 
-  it.only ('Gets data of two chains', async () => {
+  it ('Gets data of two chains', async () => {
     const linkMumbaiAddress = '0x326c977e6efc84e512bb9c30f76e30c160ed06fb';
     const charged = new Charged({providers: [{ network: 1, service: { 'alchemy': alchemyMainnetKey }}, { network: 80001, service: { 'alchemy': alchemyMumbaiKey }}]});
     const link = charged.erc20(linkMumbaiAddress);

--- a/test/integration/Erc20Service.test.ts
+++ b/test/integration/Erc20Service.test.ts
@@ -43,12 +43,14 @@ describe('NFT service class', () => {
     expect(allowanceBalance.toString()).toEqual('100000000');
   });
 
-  it ('Gets data of two chains', async () => {
+  it.only ('Gets data of two chains', async () => {
     const linkMumbaiAddress = '0x326c977e6efc84e512bb9c30f76e30c160ed06fb';
     const charged = new Charged({providers: [{ network: 1, service: { 'alchemy': alchemyMainnetKey }}, { network: 80001, service: { 'alchemy': alchemyMumbaiKey }}]});
     const link = charged.erc20(linkMumbaiAddress);
 
     const allowance = await link.allowance(signer.address, '0x51f845af34c60499a1056FCDf47BcBC681A0fA39');
-    console.log(allowance[80001].value.toString(), allowance);
+
+    const allowanceBalance = _.get(allowance, '80001.value');
+    expect(allowanceBalance.toString()).toEqual('39614081256132168796771975168');
   });
 });

--- a/test/integration/Erc20Service.test.ts
+++ b/test/integration/Erc20Service.test.ts
@@ -7,6 +7,10 @@ import * as _ from 'lodash';
 import { getWallet } from '../../src/utils/testUtilities';
 import { mainnetAddresses } from '../../src';
 import Charged from '../../src/charged/index';
+import {
+  alchemyMumbaiKey,
+  alchemyMainnetKey
+} from '../../src/utils/config';
 
 describe('NFT service class', () => {
   const signer = getWallet();
@@ -37,5 +41,14 @@ describe('NFT service class', () => {
 
     const allowanceBalance = _.get(allowanceResponse, '1.value');
     expect(allowanceBalance.toString()).toEqual('100000000');
+  });
+
+  it ('Gets data of two chains', async () => {
+    const linkMumbaiAddress = '0x326c977e6efc84e512bb9c30f76e30c160ed06fb';
+    const charged = new Charged({providers: [{ network: 1, service: { 'alchemy': alchemyMainnetKey }}, { network: 80001, service: { 'alchemy': alchemyMumbaiKey }}]});
+    const link = charged.erc20(linkMumbaiAddress);
+
+    const allowance = await link.allowance(signer.address, '0x51f845af34c60499a1056FCDf47BcBC681A0fA39');
+    console.log(allowance[80001].value.toString(), allowance);
   });
 });


### PR DESCRIPTION
Read all network method was querying the same contract on the same network, now queries are done on each chain.